### PR TITLE
Remove the deprecated function chaining syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 **BREAKING CHANGES**
 
 - Requires TypeScript 4.1 or newer
-- Remove deprecated `routeHandler()`, `run()`, `Parser.routeParams()` and
-  `Parser.routeParamsP()`.
+- Remove dhe deprecated `routeHandler()`, `run()`, `Parser.routeParams()` and
+  `Parser.routeParamsP()` functions.
+- Remvove the deprecated function chaining syntax for defining routes
 - Remove the `URL` namespace (namely `URL.int()` and `URL.str()`) in favor of
   path patterns
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ It works with both [Express] and [Koa].
     - [`router(...routes: Route<any>[]): Router`](#routerroutes-routeany-router)
     - [`Router.add(...routes: Route<any>[]): Router`](#routeraddroutes-routeany-router)
     - [`Router.handler()`](#routerhandler)
-  - [~Creating routes by function chaining~ (deprecated)](#creating-routes-by-function-chaining-deprecated)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -911,37 +910,11 @@ const app = new Koa()
 app.use(mount('/subpath', router.handler()))
 ```
 
-### ~Creating routes by function chaining~ (deprecated)
-
-_Deprecaded as of v1.0.0_: Use `route(...).use(...).handler(...)` instead.
-
-In typera versions prior to 1.0.0, routes were called with a more bizarre syntax
-like this:
-
-```typescript
-const updateUser: Route<
-  | Response.Ok<User>
-  | Response.NotFound
-  | Response.BadRequest<string>
-> = route('put', '/user/', URL.int('id'))(Parser.body(userBody))(async (request) => {
-    ...
-  })
-```
-
-As you can see, the URL patterns, middleware, and route handler are there, but
-you added them by calling functions returned by functions.
-
-In v1.0.0, the `.use()` and `.handler()` were added to make the syntax a lot
-nicer, to better support code formatting ([prettier]), and to allow using the
-previous middleware result in the next middleware (middleware chaining).
-
 [fp-ts]: https://github.com/gcanti/fp-ts
 [io-ts]: https://github.com/gcanti/io-ts
 [io-ts-types]: https://github.com/gcanti/io-ts-types
 [express]: https://expressjs.com/
 [body-parser]: https://github.com/expressjs/body-parser
 [koa]: https://koajs.com/
-[@koa/router]: https://github.com/koajs/router
 [koa-bodyparser]: https://github.com/koajs/bodyparser
 [koa-mount]: https://github.com/koajs/mount
-[prettier]: https://prettier.io

--- a/packages/typera-common/src/url.ts
+++ b/packages/typera-common/src/url.ts
@@ -39,17 +39,17 @@ type ParamsFrom<Parts> = Parts extends [infer First, ...infer Rest]
 
 export type PathToCaptures<Path> = ParamsFrom<Split<Path>>
 
-export type URLParser<Captures> = {
+export type PathParser<Captures> = {
   method: Method
-  urlPattern: string
+  pattern: string
   parse(routeParams: {}): Either.Either<Response.Generic, Captures>
 }
 
 export function url<Path extends string>(
   method: Method,
   path: Path
-): URLParser<PathToCaptures<Path>> {
-  const urlPattern = path.replace(/\(int\)/g, '(\\d+)')
+): PathParser<PathToCaptures<Path>> {
+  const pattern = path.replace(/\(int\)/g, '(\\d+)')
   const intCaptures = path
     .split('/')
     .map(s => s.split('.'))
@@ -60,7 +60,7 @@ export function url<Path extends string>(
     .map(s => s.replace(/^:(.*?)\(int\)$/, '$1'))
   return {
     method,
-    urlPattern,
+    pattern,
     parse: (routeParams: Record<string, string>): any => {
       let fail = false
       const result: Record<string, string | number> = {}

--- a/packages/typera-express/src/index.ts
+++ b/packages/typera-express/src/index.ts
@@ -34,7 +34,7 @@ class Router {
   handler(): express.Router {
     const router = express.Router()
     this._routes.forEach(route => {
-      router[route.method](route.urlPattern, run(route.routeHandler))
+      router[route.method](route.path, run(route.routeHandler))
     })
     return router
   }

--- a/packages/typera-koa/src/index.ts
+++ b/packages/typera-koa/src/index.ts
@@ -37,7 +37,7 @@ class Router {
   handler(): koa.Middleware {
     const router = new koaRouter()
     this._routes.forEach(route => {
-      router[route.method](route.urlPattern, run(route.routeHandler))
+      router[route.method](route.path, run(route.routeHandler))
     })
     return router.routes() as koa.Middleware<any, any>
   }


### PR DESCRIPTION
While at it, clarify naming around path patterns.