### PR TITLE
Case insesitive request header parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,9 +633,9 @@ Validate the query string according to the given [io-ts] codec. Respond with
 `400 Bad Request` if the validation fails.
 
 The input for this parser will be the query string parsed as
-`{ [K in string]: string }`, i.e. all parameter values will be strings. If you
-want to convert them to other types, you probably find the `FromString` codecs
-from [io-ts-types] useful (e.g. `IntFromString`, `BooleanFromString`, etc.)
+`Record<string, string>`, i.e. all parameter values will be strings. If you want
+to convert them to other types, you probably find the `FromString` codecs from
+[io-ts-types] useful (e.g. `IntFromString`, `BooleanFromString`, etc.)
 
 #### `Parser.body<T>(codec: t.Type<T>): Middleware<{ body: T }, Response.BadRequest<string>>`
 
@@ -656,9 +656,15 @@ or [Koa] app rather than use them as typera middleware.
 Validate the request headers according to the given [io-ts] codec. Respond with
 `400 Bad Request` if the validation fails.
 
+Header matching is case-insensitive, so using e.g. `X-API-KEY`, `x-api-key` and
+`X-Api-Key` in the codec will all read the same header. However, the parse
+_result_ will of course be case sensitive. That is, the field in
+`request.headers` will have the name you specify in the [io-ts] codec you pass
+to `Parser.headers`, with case preserved.
+
 The input for this parser will be the headers parsed as
-`{ [K in string]: string }`, i.e. all header values will be strings. If you want
-to convert them to other types, you probably find the `FromString` codecs from
+`Record<string, string>`, i.e. all header values will be strings. If you want to
+convert them to other types, you probably find the `FromString` codecs from
 [io-ts-types] useful (e.g. `IntFromString`, `BooleanFromString`, etc.)
 
 #### `Parser.cookies<T>(codec: t.Type<T>): Middleware<{ cookies: T }, Response.BadRequest<string>>`
@@ -667,8 +673,8 @@ Validate the request cookies according to the given [io-ts] codec. Respond with
 `400 Bad Request` if the validation fails.
 
 The input for this parser will be the cookies parsed as
-`{ [K in string]: string }`, i.e. all cookie values will be strings. If you want
-to convert them to other types, you probably find the `FromString` codecs from
+`Record<string, string>`, i.e. all cookie values will be strings. If you want to
+convert them to other types, you probably find the `FromString` codecs from
 [io-ts-types] useful (e.g. `IntFromString`, `BooleanFromString`, etc.)
 
 #### Customizing the error response

--- a/packages/typera-express/src/parser.ts
+++ b/packages/typera-express/src/parser.ts
@@ -19,7 +19,10 @@ export const queryP = commonParser.queryP(getQuery)
 export const query = commonParser.query(getQuery)
 
 function getHeaders(e: RequestBase): any {
-  return e.req.headers
+  return new Proxy(e.req, {
+    get: (target, field) =>
+      typeof field === 'string' ? target.get(field) : undefined,
+  })
 }
 export const headersP = commonParser.headersP(getHeaders)
 export const headers = commonParser.headers(getHeaders)

--- a/packages/typera-express/tests/route.spec.ts
+++ b/packages/typera-express/tests/route.spec.ts
@@ -253,6 +253,35 @@ describe('route & router', () => {
     expect(finalizer2).toEqual(1)
   })
 
+  it('case insesitive request headers', async () => {
+    const test: Route<Response.Ok<string> | Response.BadRequest<string>> = route
+      .get('/headers')
+      .use(
+        Parser.headers(
+          t.type({
+            'API-KEY': t.string,
+            'api-key': t.string,
+            'aPi-KeY': t.string,
+          })
+        )
+      )
+      .handler(async (request) =>
+        Response.ok(
+          request.headers['API-KEY'] +
+            request.headers['api-key'] +
+            request.headers['aPi-KeY']
+        )
+      )
+
+    const handler = router(test).handler()
+    const app = makeApp().use(handler)
+
+    await request(app)
+      .get('/headers')
+      .set('API-KEY', 'foo')
+      .expect(200, 'foofoofoo')
+  })
+
   it('buffer body', async () => {
     const test: Route<Response.Ok<Buffer>> = route
       .get('/buffer')

--- a/packages/typera-koa/src/parser.ts
+++ b/packages/typera-koa/src/parser.ts
@@ -19,7 +19,10 @@ export const queryP = commonParser.queryP(getQuery)
 export const query = commonParser.query(getQuery)
 
 function getHeaders(req: RequestBase): any {
-  return req.ctx.request.headers
+  return new Proxy(req.ctx, {
+    get: (target, field) =>
+      typeof field === 'string' ? target.get(field) : undefined,
+  })
 }
 export const headersP = commonParser.headersP(getHeaders)
 export const headers = commonParser.headers(getHeaders)

--- a/packages/typera-koa/tests/route.spec.ts
+++ b/packages/typera-koa/tests/route.spec.ts
@@ -248,6 +248,35 @@ describe('route & router', () => {
     expect(finalizer2).toEqual(1)
   })
 
+  it('case insesitive request headers', async () => {
+    const test: Route<Response.Ok<string> | Response.BadRequest<string>> = route
+      .get('/headers')
+      .use(
+        Parser.headers(
+          t.type({
+            'API-KEY': t.string,
+            'api-key': t.string,
+            'aPi-KeY': t.string,
+          })
+        )
+      )
+      .handler(async (request) =>
+        Response.ok(
+          request.headers['API-KEY'] +
+            request.headers['api-key'] +
+            request.headers['aPi-KeY']
+        )
+      )
+
+    const handler = router(test).handler()
+    server = makeServer(handler)
+
+    await request(server)
+      .get('/headers')
+      .set('API-KEY', 'foo')
+      .expect(200, 'foofoofoo')
+  })
+
   it('buffer body', async () => {
     const test: Route<Response.Ok<Buffer>> = route
       .get('/buffer')


### PR DESCRIPTION
Before, headers had to be accessed by their lower-cased name. Now you can use any case you want!