### PR TITLE
docs: add example about how to use `chainedMiddleware`

### DIFF
--- a/docs/apiref.md
+++ b/docs/apiref.md
@@ -289,6 +289,10 @@ const audit: Middleware.ChainedMiddleware<
 Now, the `audit` middleware can only be used if the `db` middleware comes before
 it and adds `connection` to the request object.
 
+```typescript
+const chainedAuditMiddleware = route.use(db).use(audit);
+```
+
 ## Request parsers
 
 Request parsers are built-in middleware that let you validate parts of the

--- a/docs/apiref.md
+++ b/docs/apiref.md
@@ -290,7 +290,7 @@ Now, the `audit` middleware can only be used if the `db` middleware comes before
 it and adds `connection` to the request object.
 
 ```typescript
-const chainedAuditMiddleware = route.use(db).use(audit);
+const myRoute = route.use(db).use(audit)
 ```
 
 ## Request parsers


### PR DESCRIPTION
I was going crazy trying to get `chainedMiddleware` to work and because the docs didn't specify how to actually place them, I was writing it like `route.use(firstMw, secondMw);` or `applyMiddleware(firstMw, secondMw)`.

Added a small snippet showcasing how to use it correctly.