### PR TITLE
Prevent using exact codecs with Parser.headers + improve headers Proxy

### DIFF
--- a/docs/apiref.md
+++ b/docs/apiref.md
@@ -348,9 +348,9 @@ or [Koa] app rather than use them as typera middleware.
 
 Signature: `Parser.headers(codec)`
 
-Validate the request headers according to the given [io-ts] codec. Respond with
-`400 Bad Request` if the validation fails. The result will be available as
-`request.headers` in the route handler.
+Validate the request headers according to the given non-exact [io-ts] codec.
+Respond with `400 Bad Request` if the validation fails. The result will be
+available as `request.headers` in the route handler.
 
 Header matching is case-insensitive, so using e.g. `X-API-KEY`, `x-api-key` and
 `X-Api-Key` in the codec will all read the same header. However, the parse
@@ -362,6 +362,11 @@ The input for this parser will be the headers parsed as
 `Record<string, string>`, i.e. all header values will be strings. If you want to
 convert them to other types, you probably find the `FromString` codecs from
 [io-ts-types] useful (e.g. `IntFromString`, `BooleanFromString`, etc.)
+
+Exact codecs (eg. io-ts functions `strict` & `exact`) are not supported as their
+property stripping behavior is not compatible with typera's case-preserving
+logic. Regardless, the parsing behavior is logically similar to using exact
+codecs as `request.headers` will not contain unparsed headers.
 
 ### `cookies`
 

--- a/packages/typera-common/src/parser.ts
+++ b/packages/typera-common/src/parser.ts
@@ -21,18 +21,16 @@ export const query = <RequestBase>(getQuery: GetInput<RequestBase>) =>
 
 export const headersP =
   <RequestBase>(getHeaders: GetInput<RequestBase>) =>
-  <Codec extends t.Type<any>, ErrorResponse extends Response.Generic>(
-    codec: Codec extends t.ExactType<any> ? never : Codec,
+  <A extends t.Props, ErrorResponse extends Response.Generic>(
+    codec: t.TypeC<A>,
     errorHandler: ErrorHandler<ErrorResponse>
   ) =>
     genericP(getHeaders, 'headers')(codec, errorHandler)
 
 export const headers =
   <RequestBase>(getHeaders: GetInput<RequestBase>) =>
-  <Codec extends t.Type<any>>(
-    codec: Codec extends t.ExactType<any> ? never : Codec
-  ) =>
-    generic(getHeaders, 'headers')(codec)
+  <A extends t.Props>(codec: t.TypeC<A>) =>
+    generic<RequestBase, 'headers'>(getHeaders, 'headers')(codec)
 
 export const cookiesP = <RequestBase>(getCookies: GetInput<RequestBase>) =>
   genericP(getCookies, 'cookies')

--- a/packages/typera-common/src/parser.ts
+++ b/packages/typera-common/src/parser.ts
@@ -19,11 +19,20 @@ export const queryP = <RequestBase>(getQuery: GetInput<RequestBase>) =>
 export const query = <RequestBase>(getQuery: GetInput<RequestBase>) =>
   generic(getQuery, 'query')
 
-export const headersP = <RequestBase>(getHeaders: GetInput<RequestBase>) =>
-  genericP(getHeaders, 'headers')
+export const headersP =
+  <RequestBase>(getHeaders: GetInput<RequestBase>) =>
+  <Codec extends t.Type<any>, ErrorResponse extends Response.Generic>(
+    codec: Codec extends t.ExactType<any> ? never : Codec,
+    errorHandler: ErrorHandler<ErrorResponse>
+  ) =>
+    genericP(getHeaders, 'headers')(codec, errorHandler)
 
-export const headers = <RequestBase>(getHeaders: GetInput<RequestBase>) =>
-  generic(getHeaders, 'headers')
+export const headers =
+  <RequestBase>(getHeaders: GetInput<RequestBase>) =>
+  <Codec extends t.Type<any>>(
+    codec: Codec extends t.ExactType<any> ? never : Codec
+  ) =>
+    generic(getHeaders, 'headers')(codec)
 
 export const cookiesP = <RequestBase>(getCookies: GetInput<RequestBase>) =>
   genericP(getCookies, 'cookies')

--- a/packages/typera-express/src/parser.ts
+++ b/packages/typera-express/src/parser.ts
@@ -21,6 +21,13 @@ function getHeaders(e: RequestBase): any {
   return new Proxy(e.req, {
     get: (target, field) =>
       typeof field === 'string' ? target.get(field) : undefined,
+    getOwnPropertyDescriptor() {
+      return {
+        enumerable: true,
+        configurable: true,
+      }
+    },
+    ownKeys: (target) => Object.keys(target.headers),
   })
 }
 export const headersP = commonParser.headersP(getHeaders)

--- a/packages/typera-express/tests/route.spec.ts
+++ b/packages/typera-express/tests/route.spec.ts
@@ -267,7 +267,7 @@ describe('route & router', () => {
     expect(finalizer2).toEqual(1)
   })
 
-  it('case insesitive request headers', async () => {
+  it('case insensitive request headers', async () => {
     const test: Route<Response.Ok<string> | Response.BadRequest<string>> = route
       .get('/headers')
       .use(
@@ -280,11 +280,16 @@ describe('route & router', () => {
         )
       )
       .handler(async (request) =>
-        Response.ok(
-          request.headers['API-KEY'] +
-            request.headers['api-key'] +
-            request.headers['aPi-KeY']
-        )
+        Object.getOwnPropertyNames(request.headers).includes('api-key') &&
+        Object.keys(request.headers).includes('api-key')
+          ? Response.ok(
+              [
+                request.headers['API-KEY'],
+                request.headers['api-key'],
+                request.headers['aPi-KeY'],
+              ].join('')
+            )
+          : Response.badRequest('request.headers does not include api-key')
       )
 
     const handler = router(test).handler()

--- a/packages/typera-koa/src/parser.ts
+++ b/packages/typera-koa/src/parser.ts
@@ -21,6 +21,13 @@ function getHeaders(req: RequestBase): any {
   return new Proxy(req.ctx, {
     get: (target, field) =>
       typeof field === 'string' ? target.get(field) : undefined,
+    getOwnPropertyDescriptor() {
+      return {
+        enumerable: true,
+        configurable: true,
+      }
+    },
+    ownKeys: (target) => Object.keys(target.headers),
   })
 }
 export const headersP = commonParser.headersP(getHeaders)

--- a/packages/typera-koa/tests/route.spec.ts
+++ b/packages/typera-koa/tests/route.spec.ts
@@ -262,7 +262,7 @@ describe('route & router', () => {
     expect(finalizer2).toEqual(1)
   })
 
-  it('case insesitive request headers', async () => {
+  it('case insensitive request headers', async () => {
     const test: Route<Response.Ok<string> | Response.BadRequest<string>> = route
       .get('/headers')
       .use(
@@ -275,11 +275,16 @@ describe('route & router', () => {
         )
       )
       .handler(async (request) =>
-        Response.ok(
-          request.headers['API-KEY'] +
-            request.headers['api-key'] +
-            request.headers['aPi-KeY']
-        )
+        Object.getOwnPropertyNames(request.headers).includes('api-key') &&
+        Object.keys(request.headers).includes('api-key')
+          ? Response.ok(
+              [
+                request.headers['API-KEY'],
+                request.headers['api-key'],
+                request.headers['aPi-KeY'],
+              ].join('')
+            )
+          : Response.badRequest('request.headers does not include api-key')
       )
 
     const handler = router(test).handler()

--- a/typing-tests/tests/error-exact-header-codec.ts
+++ b/typing-tests/tests/error-exact-header-codec.ts
@@ -4,10 +4,10 @@ import { Parser, Response, Route, route } from 'typera-koa'
 export const handler: Route<Response.Ok<string> | Response.BadRequest<string>> =
   route
     .get('/')
-    .use(Parser.headers(t.exact({ foo: t.string })))
+    .use(Parser.headers(t.strict({ foo: t.string })))
     .handler((_req) => {
       return Response.ok('😎')
     })
 
 // Expected error:
-// Argument of type 'ExactC<HasProps>' is not assignable to parameter of type 'never'.
+// Argument of type 'ExactC<TypeC<{ foo: StringC; }>>' is not assignable to parameter of type 'TypeC<Props>'.

--- a/typing-tests/tests/error-exact-header-codec.ts
+++ b/typing-tests/tests/error-exact-header-codec.ts
@@ -1,0 +1,13 @@
+import * as t from 'io-ts'
+import { Parser, Response, Route, route } from 'typera-koa'
+
+export const handler: Route<Response.Ok<string> | Response.BadRequest<string>> =
+  route
+    .get('/')
+    .use(Parser.headers(t.exact({ foo: t.string })))
+    .handler((_req) => {
+      return Response.ok('😎')
+    })
+
+// Expected error:
+// Argument of type 'ExactC<HasProps>' is not assignable to parameter of type 'never'.


### PR DESCRIPTION
Exact io-ts codecs do not work with typera's Parser.headers. This is because of two reasons:
1) the request.headers Proxy returns the wrong values when io-ts checks its `Object.getOwnPropertyNames` and
2) the user is supposed to pick any preferred header casing in the codec but io-ts only sees all-lowercase header inputs from express/koa.

My attempt at a solution:
* Make using exact codecs with Parser.headers a type error
* Mention this limitation and the inherently exact-like parsing behavior in docs
* Add `ownKeys` to `request.headers` Proxy so that `Object.getOwnPropertyNames` works, and `getOwnPropertyDescriptor` so that `Object.keys` uses the same function.

Closes https://github.com/akheron/typera/issues/389
