### PR TITLE
Fix a typo in the docs

### DIFF
--- a/docs/apiref.md
+++ b/docs/apiref.md
@@ -454,7 +454,7 @@ function errorToString(err: t.Errors): string {
 
 const myQuery = <T>(
   codec: t.Type<T>
-): Middleware<{ body: T }, Response.BadRequest<string>> =>
+): Middleware<{ query: T }, Response.BadRequest<string>> =>
   Parser.queryP(codec, (errors) => Response.badRequest(errorToString(errors)))
 
 // You can alse return a different response than 400 Bad Request


### PR DESCRIPTION
The code provided won't compile.

This part of the docs is describing how to make a custom query parse error handler.